### PR TITLE
rem 1 timeline post, add 1 transl key, removed countdown

### DIFF
--- a/packages/rainbow/components/pages/home/donors-section.tsx
+++ b/packages/rainbow/components/pages/home/donors-section.tsx
@@ -95,7 +95,11 @@ function DonorLeaderboard() {
               {translations.donorsSection.table.headings.amountDonated}
             </th>
             {/* hidden element to compensate for scrollbar causing layout shift */}
-            <th ref={ref} aria-hidden="true" />
+            <th
+              ref={ref}
+              aria-hidden="true"
+              className="donors-section__scrollbar-fix"
+            />
           </tr>
         </thead>
         <tbody className="w-full">
@@ -137,7 +141,21 @@ async function fetchLeaderboard() {
   return await (response.json() as Promise<Leaderboard>);
 }
 
+function isIOSDevice(): boolean {
+  // This regex will match iPad, iPhone, and iPod user agent strings
+  return (
+    /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+    // iPad on iOS 13 detection
+    (navigator.userAgent.includes("Mac") && "ontouchend" in document)
+  );
+}
+
 function getScrollbarWidth() {
+  if (isIOSDevice()) {
+    // On iOS devices, the scrollbar is overlaid on the content and does not take up space.
+    return 0;
+  }
+
   // Creating invisible container
   const outer = document.createElement("div");
   outer.style.visibility = "hidden";

--- a/packages/rainbow/components/pages/home/hero-section.tsx
+++ b/packages/rainbow/components/pages/home/hero-section.tsx
@@ -33,7 +33,6 @@ const CountdownClientComponent = dynamic(
 );
 
 export function HeroSection({ className }: { className?: string }) {
-  const isRevealed = isAfter(new Date(), countdownDate);
   const { translations } = useTranslation();
 
   return (
@@ -41,35 +40,17 @@ export function HeroSection({ className }: { className?: string }) {
       id="hero-section"
       className={classNames("hero-section", className)}
     >
-      {/* <CountdownClientComponent
-        date={countdownDate}
-        renderer={(props) => <CountdownRenderer {...props} />}
-      /> */}
-
       <h1 className="hero-section__title">
         {translations.hero["title.revealed"]}
       </h1>
 
       <div className="hero-section__image-wrapper">
         <img
-          src={`./images/rainbow/bronze-statue-${
-            isRevealed ? "revealed" : "hidden"
-          }.png`}
+          src={`./images/rainbow/bronze-statue-revealed.png`}
           alt="A bronze doge statue."
           className="hero-section__image"
         />
       </div>
-
-      {/* <div className="hero-section__play-button-wrapper">
-        <button className="hero-section__play-button">
-          <img
-            src={`./images/rainbow/play-video-${
-              locale === "ja" ? "ja" : "en"
-            }.svg`}
-            alt="Play video"
-          />
-        </button>
-      </div> */}
 
       <ClientSidePlayVideoDialog />
     </section>

--- a/packages/rainbow/components/pages/home/hero-section.tsx
+++ b/packages/rainbow/components/pages/home/hero-section.tsx
@@ -34,15 +34,21 @@ const CountdownClientComponent = dynamic(
 
 export function HeroSection({ className }: { className?: string }) {
   const isRevealed = isAfter(new Date(), countdownDate);
+  const { translations } = useTranslation();
+
   return (
     <section
       id="hero-section"
       className={classNames("hero-section", className)}
     >
-      <CountdownClientComponent
+      {/* <CountdownClientComponent
         date={countdownDate}
         renderer={(props) => <CountdownRenderer {...props} />}
-      />
+      /> */}
+
+      <h1 className="hero-section__title">
+        {translations.hero["title.revealed"]}
+      </h1>
 
       <div className="hero-section__image-wrapper">
         <img

--- a/packages/rainbow/components/pages/home/history-section.tsx
+++ b/packages/rainbow/components/pages/home/history-section.tsx
@@ -139,22 +139,22 @@ export function HistorySection({ className }: { className?: string }) {
           .bronzeTheDogeDogePilgrimageandDogeDocumentary.title,
       className: "bronzeTheDogeDogePilgrimageandDogeDocumentary",
     },
-    {
-      id: "dogeLegacy",
-      eventImageSrc: "./images/rainbow/timeline-events/2024.png",
-      eventCaption: (
-        <>
-          <span>2</span>
-          <span>0</span>
-          <span>2</span>
-          <span>4</span>
-        </>
-      ),
-      articleImageSrc: "./images/rainbow/decoration/doge-share.png",
-      articleContent: translations.timeline.articles.dogeLegacy.content,
-      articleTitle: translations.timeline.articles.dogeLegacy.title,
-      className: "dogeLegacy",
-    },
+    // {
+    //   id: "dogeLegacy",
+    //   eventImageSrc: "./images/rainbow/timeline-events/2024.png",
+    //   eventCaption: (
+    //     <>
+    //       <span>2</span>
+    //       <span>0</span>
+    //       <span>2</span>
+    //       <span>4</span>
+    //     </>
+    //   ),
+    //   articleImageSrc: "./images/rainbow/decoration/doge-share.png",
+    //   articleContent: translations.timeline.articles.dogeLegacy.content,
+    //   articleTitle: translations.timeline.articles.dogeLegacy.title,
+    //   className: "dogeLegacy",
+    // },
   ];
 
   return (

--- a/packages/rainbow/locales/ja.json
+++ b/packages/rainbow/locales/ja.json
@@ -6,7 +6,7 @@
   },
   "hero": {
     "title.hidden": "銅像がお披露目される",
-    "title.revealed": "[THE STATUE IS REVEALED]"
+    "title.revealed": "銅像が明らかになる"
   },
   "countDown": {
     "days": "日々",

--- a/packages/rainbow/styles/globals.css
+++ b/packages/rainbow/styles/globals.css
@@ -157,10 +157,17 @@ html {
 .hero-section .countdown-renderer {
   @apply flex flex-col items-center;
   @apply w-full;
-  @apply text-white;
+  @apply text-white text-shadow;
   @apply mt-0 md:mt-24;
+}
 
+.text-shadow {
   text-shadow: 0px 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.hero-section__title {
+  @apply text-3xl md:text-6xl text-center text-shadow font-bold;
+  @apply px-8 my-16 md:my-32;
 }
 
 .hero-section .countdown-renderer__title {
@@ -206,8 +213,8 @@ html {
 }
 
 .hero-section__play-button-wrapper {
-  @apply absolute top-0 left-1/2;
-  @apply container mx-auto h-full;
+  @apply absolute bottom-0 left-1/2;
+  @apply container mx-auto h-3/4 md:h-full;
   @apply -translate-x-1/2;
   @apply flex items-start md:items-end justify-end;
   @apply px-12 pb-20 pt-40 md:p-24;
@@ -471,6 +478,10 @@ html {
 
 thead th {
   @apply sticky top-0 z-10;
+}
+
+.donors-section__scrollbar-fix {
+  @apply p-0;
 }
 
 tbody {


### PR DESCRIPTION
Removed:
The timeline post about 2024
The countdown counting down to nov. 2 15:00

Added:
1 missing translation key in japanese for "The statue is revealed". Since I don't speak Japanese, I used chatgpt to generate this so I can't attest to its accuracy.

Modified:
Enlarged the title in the hero to take some space left behind by the countdown, and adjusted the image below accordingly.